### PR TITLE
cleaning up std ravello vars

### DIFF
--- a/roles/ravello.applications_start/defaults/main.yaml
+++ b/roles/ravello.applications_start/defaults/main.yaml
@@ -1,2 +1,3 @@
 
 ravello_apps_list: []
+ravello_expiration_time_min: 120

--- a/roles/ravello.applications_start/tasks/main.yaml
+++ b/roles/ravello.applications_start/tasks/main.yaml
@@ -10,7 +10,7 @@
         password: "{{ ravello_login_password }}"
       register: apps
       run_once: true
-      with_items: "{{ ravello_apps_list }}"
+      with_items: "{{ ravello_app_list }}"
 
 ###############################
 ##  Start the application   ##

--- a/roles/ravello.applications_start/tasks/main.yaml
+++ b/roles/ravello.applications_start/tasks/main.yaml
@@ -20,8 +20,8 @@
       uri:
         url: "https://cloud.ravellosystems.com/api/v1/applications/{{ item.json.id }}/start"
         method: POST
-        user: "{{ ravello_login.username }}"
-        password: "{{ ravello_login.password }}"
+        user: "{{ ravello_login_username }}"
+        password: "{{ ravello_login_password }}"
         force_basic_auth: yes
         status_code: 202
         HEADER_Content-Type: 'application/json'
@@ -34,13 +34,13 @@
       uri:
         url: "https://cloud.ravellosystems.com/api/v1/applications/{{ item.json.id }}/setExpiration"
         method: POST
-        user: "{{ ravello_login.username }}"
-        password: "{{ ravello_login.password }}"
+        user: "{{ ravello_login_username }}"
+        password: "{{ ravello_login_password }}"
         force_basic_auth: yes
         status_code: 200
         HEADER_Content-Type: 'application/json'
         HEADER_Accept: 'application/json'
-        body: '{  "expirationFromNowSeconds": {{ ravello.expiration_time_min * 60 }} }'
+        body: '{  "expirationFromNowSeconds": {{ ravello_expiration_time_min * 60 }} }'
         body_format: json
       run_once: true
       with_items: "{{ apps.results }}"


### PR DESCRIPTION
there appears to be some inconsistency with the way we specify ravello
vars, maybe an old style vs a new style?

this commit removes inconsistent dot notation in the applications_start
role