### PR TITLE
fix the insertafter regex to correctly match the application name

### DIFF
--- a/roles/ravello.applications_create/tasks/main.yaml
+++ b/roles/ravello.applications_create/tasks/main.yaml
@@ -161,7 +161,7 @@
         dest: "{{ ravello_fqdn_dir }}//{{ ravello_fqdn_file_name }}.yaml"
         line: "  {{ inventory_hostname }}: {{ item.json.value }}"
         create: yes
-        insertafter: "^{{ item.item.item.item.app_name }}"
+        insertafter: "^{{ item.item.item.item.app_name }}:"
       with_items: "{{ public_ip.results }}"
       tags: [ fqdn ]
 


### PR DESCRIPTION
insertafter statement was incorrectly matching shortest prefix on on
application names. added end of application name marker to regex.